### PR TITLE
add const declarations

### DIFF
--- a/platform/samd11/usb.c
+++ b/platform/samd11/usb.c
@@ -113,7 +113,7 @@ void usb_handle_standard_request(usb_request_t *request)
         }
         else if (index < USB_STR_COUNT)
         {
-          char *str = usb_strings[index];
+          const char *str = usb_strings[index];
           int len = strlen(str);
 
           memset(usb_string_descriptor_buffer, 0, sizeof(usb_string_descriptor_buffer));

--- a/platform/samd11/usb_descriptors.c
+++ b/platform/samd11/usb_descriptors.c
@@ -139,7 +139,7 @@ const alignas(4) usb_string_descriptor_zero_t usb_string_descriptor_zero =
 
 char usb_serial_number[16];
 
-char *usb_strings[] =
+const char *const usb_strings[] =
 {
   [USB_STR_MANUFACTURER]  = "Alex Taradov",
   [USB_STR_PRODUCT]       = "Generic CMSIS-DAP Adapter",

--- a/platform/samd11/usb_descriptors.h
+++ b/platform/samd11/usb_descriptors.h
@@ -78,7 +78,7 @@ extern const usb_device_descriptor_t usb_device_descriptor;
 extern const usb_configuration_hierarchy_t usb_configuration_hierarchy;
 extern const uint8_t usb_hid_report_descriptor[33];
 extern const usb_string_descriptor_zero_t usb_string_descriptor_zero;
-extern char *usb_strings[];
+extern const char *const usb_strings[];
 extern uint8_t usb_string_descriptor_buffer[64];
 
 #endif // _USB_DESCRIPTORS_H_

--- a/platform/samd21/usb.c
+++ b/platform/samd21/usb.c
@@ -113,7 +113,7 @@ void usb_handle_standard_request(usb_request_t *request)
         }
         else if (index < USB_STR_COUNT)
         {
-          char *str = usb_strings[index];
+          const char *str = usb_strings[index];
           int len = strlen(str);
 
           memset(usb_string_descriptor_buffer, 0, sizeof(usb_string_descriptor_buffer));

--- a/platform/samd21/usb_descriptors.c
+++ b/platform/samd21/usb_descriptors.c
@@ -32,7 +32,7 @@
 #include "usb_descriptors.h"
 
 /*- Variables ---------------------------------------------------------------*/
-ALIGNED(4) usb_device_descriptor_t usb_device_descriptor =
+ALIGNED(4) const usb_device_descriptor_t usb_device_descriptor =
 {
   .bLength            = sizeof(usb_device_descriptor_t),
   .bDescriptorType    = USB_DEVICE_DESCRIPTOR,
@@ -50,7 +50,7 @@ ALIGNED(4) usb_device_descriptor_t usb_device_descriptor =
   .bNumConfigurations = 1,
 };
 
-ALIGNED(4) usb_configuration_hierarchy_t usb_configuration_hierarchy =
+ALIGNED(4) const usb_configuration_hierarchy_t usb_configuration_hierarchy =
 {
   .configuration =
   {
@@ -109,7 +109,7 @@ ALIGNED(4) usb_configuration_hierarchy_t usb_configuration_hierarchy =
   },
 };
 
-ALIGNED(4) uint8_t usb_hid_report_descriptor[33] =
+ALIGNED(4) const uint8_t usb_hid_report_descriptor[33] =
 {
   0x06, 0x00, 0xff,  // Usage Page (Vendor Defined 0xFF00)
   0x09, 0x01,        // Usage (0x01)
@@ -129,14 +129,14 @@ ALIGNED(4) uint8_t usb_hid_report_descriptor[33] =
   0xc0,              // End Collection
 };
 
-ALIGNED(4) usb_string_descriptor_zero_t usb_string_descriptor_zero =
+ALIGNED(4) const usb_string_descriptor_zero_t usb_string_descriptor_zero =
 {
   .bLength               = sizeof(usb_string_descriptor_zero_t),
   .bDescriptorType       = USB_STRING_DESCRIPTOR,
   .wLANGID               = 0x0409, // English (United States)
 };
 
-char *usb_strings[] =
+const char *const usb_strings[] =
 {
   [USB_STR_MANUFACTURER]  = "Alex Taradov",
   [USB_STR_PRODUCT]       = "Generic CMSIS-DAP Adapter",

--- a/platform/samd21/usb_descriptors.h
+++ b/platform/samd21/usb_descriptors.h
@@ -74,11 +74,11 @@ typedef struct PACK
 } usb_configuration_hierarchy_t;
 
 //-----------------------------------------------------------------------------
-extern usb_device_descriptor_t usb_device_descriptor;
-extern usb_configuration_hierarchy_t usb_configuration_hierarchy;
-extern uint8_t usb_hid_report_descriptor[33];
-extern usb_string_descriptor_zero_t usb_string_descriptor_zero;
-extern char *usb_strings[];
+extern const usb_device_descriptor_t usb_device_descriptor;
+extern const usb_configuration_hierarchy_t usb_configuration_hierarchy;
+extern const uint8_t usb_hid_report_descriptor[33];
+extern const usb_string_descriptor_zero_t usb_string_descriptor_zero;
+extern const char *const usb_strings[];
 extern uint8_t usb_string_descriptor_buffer[64];
 
 #endif // _USB_DESCRIPTORS_H_


### PR DESCRIPTION
There is opportunity to declare "usb_strings" as a const char *const in both D11 and D21 variants.  The D11 variant already benefits from const declarations of the USB descriptors; I merely applied the same to the D21 variant.  Both modifications save allocated RAM and the need to copy these from flash to RAM upon initialization.