### PR TITLE
Increase USB buffer size

### DIFF
--- a/platform/samd11/usb_descriptors.c
+++ b/platform/samd11/usb_descriptors.c
@@ -148,5 +148,5 @@ const char *const usb_strings[] =
   [USB_STR_INTERFACE]     = "Main Interface",
 };
 
-alignas(4) uint8_t usb_string_descriptor_buffer[64];
+alignas(4) uint8_t usb_string_descriptor_buffer[128];
 

--- a/platform/samd11/usb_descriptors.h
+++ b/platform/samd11/usb_descriptors.h
@@ -79,7 +79,7 @@ extern const usb_configuration_hierarchy_t usb_configuration_hierarchy;
 extern const uint8_t usb_hid_report_descriptor[33];
 extern const usb_string_descriptor_zero_t usb_string_descriptor_zero;
 extern const char *const usb_strings[];
-extern uint8_t usb_string_descriptor_buffer[64];
+extern uint8_t usb_string_descriptor_buffer[128];
 
 #endif // _USB_DESCRIPTORS_H_
 

--- a/platform/samd21/usb_descriptors.c
+++ b/platform/samd21/usb_descriptors.c
@@ -145,5 +145,5 @@ const char *const usb_strings[] =
   [USB_STR_INTERFACE]     = "Main Interface",
 };
 
-ALIGNED(4) uint8_t usb_string_descriptor_buffer[64];
+ALIGNED(4) uint8_t usb_string_descriptor_buffer[128];
 

--- a/platform/samd21/usb_descriptors.h
+++ b/platform/samd21/usb_descriptors.h
@@ -79,7 +79,7 @@ extern const usb_configuration_hierarchy_t usb_configuration_hierarchy;
 extern const uint8_t usb_hid_report_descriptor[33];
 extern const usb_string_descriptor_zero_t usb_string_descriptor_zero;
 extern const char *const usb_strings[];
-extern uint8_t usb_string_descriptor_buffer[64];
+extern uint8_t usb_string_descriptor_buffer[128];
 
 #endif // _USB_DESCRIPTORS_H_
 


### PR DESCRIPTION
When defining a long product name, it might not be transferred correctly via USB HID since the string is cut.

This is a quick and dirty solution to my problem which I did not yet verify on hardware. I wanted to discuss a path forward first.

If the number of octets in `usb_string_descriptor_buffer` is fixed to `64` by the USB spec (which I don't know) we should statically assert all USB descriptor strings are shorter then 32 characters (I guess because of UTF-16 transfer encoding?).