### PR TITLE
Centralized pin configuration

### DIFF
--- a/platform/samd11_vcp/dap_config.h
+++ b/platform/samd11_vcp/dap_config.h
@@ -31,13 +31,9 @@
 
 /*- Includes ----------------------------------------------------------------*/
 #include "samd11.h"
-#include "hal_gpio.h"
+#include "hal_config.h"
 
 /*- Definitions -------------------------------------------------------------*/
-HAL_GPIO_PIN(SWCLK_TCK,    A, 14)
-HAL_GPIO_PIN(SWDIO_TMS,    A, 15)
-HAL_GPIO_PIN(nRESET,       A, 9)
-
 #define DAP_CONFIG_ENABLE_SWD
 //#define DAP_CONFIG_ENABLE_JTAG
 

--- a/platform/samd11_vcp/hal_config.h
+++ b/platform/samd11_vcp/hal_config.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Alex Taradov <alex@taradov.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _HAL_CONFIG_H_
+#define _HAL_CONFIG_H_
+
+/*- Includes ----------------------------------------------------------------*/
+#include "hal_gpio.h"
+
+/*- Definitions -------------------------------------------------------------*/
+HAL_GPIO_PIN(SWCLK_TCK,    A, 14)
+HAL_GPIO_PIN(SWDIO_TMS,    A, 15)
+HAL_GPIO_PIN(nRESET,       A, 9)
+
+HAL_GPIO_PIN(VCP_STATUS,   A, 2);
+HAL_GPIO_PIN(DAP_STATUS,   A, 4);
+HAL_GPIO_PIN(BOOT_ENTER,   A, 31);
+
+HAL_GPIO_PIN(UART_TX,      A, 8);
+HAL_GPIO_PIN(UART_RX,      A, 5);
+
+HAL_GPIO_PIN(USB_DM,       A, 24);
+HAL_GPIO_PIN(USB_DP,       A, 25);
+
+#endif // _HAL_CONFIG_H_
+

--- a/platform/samd11_vcp/main.c
+++ b/platform/samd11_vcp/main.c
@@ -33,7 +33,7 @@
 #include <stdalign.h>
 #include <string.h>
 #include "samd11.h"
-#include "hal_gpio.h"
+#include "hal_config.h"
 #include "nvm_data.h"
 #include "usb.h"
 #include "uart.h"
@@ -44,10 +44,6 @@
 #define USB_BUFFER_SIZE        64
 #define UART_WAIT_TIMEOUT      10 // ms
 #define STATUS_TIMEOUT         250 // ms
-
-HAL_GPIO_PIN(VCP_STATUS,       A, 2);
-HAL_GPIO_PIN(DAP_STATUS,       A, 4);
-HAL_GPIO_PIN(BOOT_ENTER,       A, 31);
 
 /*- Variables ---------------------------------------------------------------*/
 static alignas(4) uint8_t app_request_buffer[DAP_CONFIG_PACKET_SIZE];

--- a/platform/samd11_vcp/uart.c
+++ b/platform/samd11_vcp/uart.c
@@ -33,15 +33,12 @@
 #include <stdbool.h>
 #include <string.h>
 #include "samd11.h"
-#include "hal_gpio.h"
+#include "hal_config.h"
 #include "uart.h"
 #include "usb_cdc.h"
 
 /*- Definitions -------------------------------------------------------------*/
 #define UART_BUF_SIZE            256
-
-HAL_GPIO_PIN(UART_TX,            A, 8);
-HAL_GPIO_PIN(UART_RX,            A, 5);
 
 #define UART_SERCOM              SERCOM0
 #define UART_SERCOM_PMUX         PORT_PMUX_PMUXE_D_Val

--- a/platform/samd11_vcp/usb.c
+++ b/platform/samd11_vcp/usb.c
@@ -31,7 +31,7 @@
 #include <stdbool.h>
 #include <stdalign.h>
 #include "samd11.h"
-#include "hal_gpio.h"
+#include "hal_config.h"
 #include "utils.h"
 #include "nvm_data.h"
 #include "usb.h"
@@ -39,9 +39,6 @@
 #include "usb_descriptors.h"
 
 /*- Definitions -------------------------------------------------------------*/
-HAL_GPIO_PIN(USB_DM,   A, 24);
-HAL_GPIO_PIN(USB_DP,   A, 25);
-
 enum
 {
   USB_DEVICE_EPCFG_EPTYPE_DISABLED    = 0,


### PR DESCRIPTION
I'm using free-dap on a custom board, using the `samd11_vcp` platform. In order to stay as close as possible to upstream, it would be great if we could centralize the HAL configuration in one file for easier patching.

While the HAL functions are now defined in more compilation units, it should not have a negative impact on the resulting binary, since the unused static functions will be stripped.