### PR TITLE
add dap_init() at beginning of main() for same70

### DIFF
--- a/platform/same70/main.c
+++ b/platform/same70/main.c
@@ -270,6 +270,7 @@ int main(void)
   serial_number_init();
   usb_init();
   usb_hid_init();
+  dap_init();
 
   app_status_timer.interval = STATUS_TIMEOUT;
   app_status_timer.repeat = true;


### PR DESCRIPTION
Seems that not having this here was a bug. I was able to use free-dap to program a samd21 with the same70 without any changes (besides pin configs) a few months ago when I was testing it with the same70 explained dev board, but recently when trying to use a same70 on a custom board, I ran into issues where it would hit the dummy handler if I try to connect to a target device when no target is connected.

```
#0  irq_handler_dummy () at ../startup_same70.c:238
#1  <signal handler called>
#2  0x00000000 in ?? ()
#3  0x004011ae in dap_swj_sequence () at ../../../dap.c:1163
#4  0x0040177a in dap_process_request (req=<optimized out>, req_size=req_size@entry=1024, resp=<optimized out>, 
    resp_size=resp_size@entry=1024) at ../../../dap.c:1433
#5  0x004003e0 in dap_task () at ../main.c:242
#6  main () at ../main.c:291
(gdb) 
```

looks like the line `    dap_swd_write(dap_req_get_byte(), sz);` segfaults, because `dap_swd_write` was uninitialized. 

How this ever worked for me a few months ago, I'm not sure. It might be that when a target board is properly connected, a different code path executes where `dap_init` is called before `dap_swd_write`. In my recent testing, I didn't actually have a target connected. Adding `dap_init()` to main fixes this issue.