### PR TITLE
Build free-dap using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: sudo apt-get -y install gcc gcc-arm-none-eabi make
+
+    - name: rp2040
+      run: |
+        make --directory 'platform/rp2040/tools' -f 'Makefile' clean && \
+        make --directory 'platform/rp2040/tools' -f 'Makefile' && \
+        \
+        make --directory 'platform/rp2040/make' -f 'Makefile' clean && \
+        make --directory 'platform/rp2040/make' -f 'Makefile'
+
+    - name: samd11 (bl 2k)
+      run: |
+        make --directory 'platform/samd11/make' -f 'Makefile_bl_2k' clean && \
+        make --directory 'platform/samd11/make' -f 'Makefile_bl_2k'
+
+    - name: samd11 (no bl)
+      run: |
+        make --directory 'platform/samd11/make' -f 'Makefile_nobl' clean && \
+        make --directory 'platform/samd11/make' -f 'Makefile_nobl'
+
+    - name: samd21
+      run: |
+        make --directory 'platform/samd21/make' -f 'Makefile' clean && \
+        make --directory 'platform/samd21/make' -f 'Makefile'
+
+    - name: same70
+      run: |
+        make --directory 'platform/same70/make' -f 'Makefile' clean && \
+        make --directory 'platform/same70/make' -f 'Makefile'
+

--- a/platform/rp2040/make/Makefile
+++ b/platform/rp2040/make/Makefile
@@ -5,6 +5,7 @@ BIN = free_dap_rp2040
 ##############################################################################
 .PHONY: all directory clean size release
 
+BIN2UF2 = ../tools/bin2uf2
 CC = arm-none-eabi-gcc
 OBJCOPY = arm-none-eabi-objcopy
 SIZE = arm-none-eabi-size
@@ -68,7 +69,7 @@ $(BUILD)/$(BIN).bin: $(BUILD)/$(BIN).elf
 
 $(BUILD)/$(BIN).uf2: $(BUILD)/$(BIN).bin
 	@echo BIN2UF2 $@
-	@bin2uf2 -i $^ -o $@
+	@$(BIN2UF2) -i $^ -o $@
 
 %.o:
 	@echo CC $@


### PR DESCRIPTION
It took me some time to figure out where to get bin2uf2 from, before discovering you ship an embedded implementation. In order to help the next person I think it would be beneficial to include a runnable documentation as GitHub Actions build description.

Building the different platforms using multiple steps instead of multiple jobs since each build is quite small, thus using multiple jobs would take far longer on CI