### PR TITLE
Enable override of HAL_BOARD via compiler flags

### DIFF
--- a/platform/samd11/hal_config.h
+++ b/platform/samd11/hal_config.h
@@ -9,7 +9,11 @@
 #include "hal_gpio.h"
 
 /*- Definitions -------------------------------------------------------------*/
-#if !defined(HAL_BOARD_STD) && !defined(HAL_BOARD_VCP_V1) && !defined(HAL_BOARD_VCP_V3)
+#if !defined(HAL_BOARD_STD) && \
+    !defined(HAL_BOARD_VCP_V1) && \
+    !defined(HAL_BOARD_VCP_V3) && \
+    !defined(HAL_BOARD_CUSTOM)
+
   //#define HAL_BOARD_STD
   //#define HAL_BOARD_VCP_V1
   #define HAL_BOARD_VCP_V3
@@ -75,6 +79,10 @@
   #define UART_SERCOM_IRQ_HANDLER  irq_handler_sercom1
   #define UART_SERCOM_TXPO         1
   #define UART_SERCOM_RXPO         3
+
+#elif defined(HAL_BOARD_CUSTOM)
+  #include HAL_BOARD_CUSTOM
+
 #else
   #error No board defined
 #endif

--- a/platform/samd11/hal_config.h
+++ b/platform/samd11/hal_config.h
@@ -9,9 +9,11 @@
 #include "hal_gpio.h"
 
 /*- Definitions -------------------------------------------------------------*/
-//#define HAL_BOARD_STD
-//#define HAL_BOARD_VCP_V1
-#define HAL_BOARD_VCP_V3
+#if !defined(HAL_BOARD_STD) && !defined(HAL_BOARD_VCP_V1) && !defined(HAL_BOARD_VCP_V3)
+  //#define HAL_BOARD_STD
+  //#define HAL_BOARD_VCP_V1
+  #define HAL_BOARD_VCP_V3
+#endif
 
 #if defined(HAL_BOARD_STD)
   #define DAP_CONFIG_ENABLE_JTAG


### PR DESCRIPTION
Currently I'm changing the HAL configuration to my needs by overriding `hal_config.h`. These commits enable injecting a custom HAL without changing core files.

It's OK for me if you do not want to carry this patch and instead see overwriting `hal_config.h` as sufficient customization point.