### PR TITLE
Provide HAL_BOARD_CUSTOM as injection point for custom HAL configuration

### DIFF
--- a/platform/samd11/hal_config.h
+++ b/platform/samd11/hal_config.h
@@ -9,9 +9,13 @@
 #include "hal_gpio.h"
 
 /*- Definitions -------------------------------------------------------------*/
-//#define HAL_BOARD_STD
-//#define HAL_BOARD_VCP_V1
-#define HAL_BOARD_VCP_V3
+#if defined(HAL_BOARD_CUSTOM)
+  #include HAL_BOARD_CUSTOM
+#else
+  //#define HAL_BOARD_STD
+  //#define HAL_BOARD_VCP_V1
+  #define HAL_BOARD_VCP_V3
+#endif
 
 #if defined(HAL_BOARD_STD)
   #define DAP_CONFIG_ENABLE_JTAG


### PR DESCRIPTION
Currently I'm changing the HAL configuration to my needs by overriding `hal_config.h`. These commits enable injecting a custom HAL without changing core files.

As discussed in PR #23, we are doing `#if defined(HAL_BOARD_CUSTOM)` as a first check and escape hatch.